### PR TITLE
Add package reference for Google store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.1.1
+
+- Added google store package field

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Release NFT Metadata Spec v0.1
+# Release NFT Metadata Spec v0.1.1
 
 This is the official spec of the off-chain metadata that will be created for the NFT release management system.
 


### PR DESCRIPTION
The JSON key value makes specific reference to "Google" since there is at least one other major app store for Android. This way it's clear that the publisher is referencing something deployed there.