### PR TITLE
Fix local build failures

### DIFF
--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -1,3 +1,1 @@
 lib
-src/generated/config_obj.json
-src/generated/config_schema.json

--- a/packages/cli/src/generated/.gitignore
+++ b/packages/cli/src/generated/.gitignore
@@ -1,0 +1,2 @@
+config_obj.json
+config_schema.json


### PR DESCRIPTION
`schemagen.js` fails to create config files `config_obj.json` and `config_schema.json` since the directory doesnt exist. 
This little maneuver ensures that the generated directory is always present.  