### PR TITLE
Improved Android tools error handling

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -17,9 +17,13 @@ Corepack requires a version to enable, so if you don't have [jq](https://stedola
 corepack prepare pnpm@7.13.4 --activate
 ```
 
-You must have the Android SDK build tools available for use by the `dapp-store` CLI. If you have Android Studio, these tools are available as part of that installation (for e.g., on MacOS, they can be found in ~/Library/Android/sdk/build-tools/<version>). If you do not have Android Studio installed, or wish to use a standalone version of the Android SDK build tools, please follow the instructions [here](https://developer.android.com/studio/intro/update#sdk-manager). The path to the SDK build tools can be provided either directly to subcommands that require it with the `-b` option, or indirectly via a `.env` file:
+### Android SDK Tools
+
+You must have the Android SDK build tools available for use by the `dapp-store` CLI. If you have Android Studio, these tools are available as part of that installation (for e.g., on MacOS, they can be found in ~/Library/Android/sdk/build-tools/<version>). If you do not have Android Studio installed, or wish to use a standalone version of the Android SDK build tools, please follow the instructions [here](https://developer.android.com/studio/intro/update#sdk-manager).
+
+The path to the SDK build tools can be provided either directly to subcommands that require it with the `-b` option, or indirectly via a `.env` file. Please provide a path to a specific, recent version of the SDK tools (e.g., `~/Library/Android/sdk/build-tools/33.0.0`) as older versions do not have the requisite dependency: 
 ```
-echo "ANDROID_TOOLS_DIR=\"<path_to_android_sdk_build_tools_dir>\"" > .env
+echo "ANDROID_TOOLS_DIR=\"<path_to_android_sdk_version_build_tools_dir>\"" > .env
 ```
 
 ## Usage

--- a/packages/cli/src/config/PublishDetails.ts
+++ b/packages/cli/src/config/PublishDetails.ts
@@ -66,16 +66,16 @@ export const loadPublishDetailsWithChecks = async (
 
   const config = await loadPublishDetails(configFilePath);
 
-  if (buildToolsDir && fs.lstatSync(buildToolsDir).isDirectory()) {
-    // We validate that the config is going to have at least one installable asset
-    const apkEntry = config.release.files.find(
-      (asset: PublishDetails["release"]["files"][0]) => asset.purpose === "install"
-    )!;
-    const apkPath = path.join(process.cwd(), apkEntry?.uri);
-    if (!fs.existsSync(apkPath)) {
-      throw new Error("Invalid path to APK file.");
-    }
+  // We validate that the config is going to have at least one installable asset
+  const apkEntry = config.release.files.find(
+    (asset: PublishDetails["release"]["files"][0]) => asset.purpose === "install"
+  )!;
+  const apkPath = path.join(process.cwd(), apkEntry?.uri);
+  if (!fs.existsSync(apkPath)) {
+    throw new Error("Invalid path to APK file.");
+  }
 
+  if (buildToolsDir) {
     config.release.android_details = await getAndroidDetails(
       buildToolsDir,
       apkPath
@@ -197,50 +197,59 @@ const getAndroidDetails = async (
   aaptDir: string,
   apkPath: string
 ): Promise<AndroidDetails> => {
-  const { stdout } = await runExec(`${aaptDir}/aapt2 dump badging ${apkPath}`);
+  //fs.lstatSync(buildToolsDir).isDirectory()
+  //1. Not a directory
+  //2. Not a diretctory with aapt2
+  //3. Escaping path
 
-  const appPackage = new RegExp(
-    AaptPrefixes.packagePrefix + AaptPrefixes.quoteRegex
-  ).exec(stdout);
-  const versionCode = new RegExp(
-    AaptPrefixes.verCodePrefix + AaptPrefixes.quoteRegex
-  ).exec(stdout);
-  const versionName = new RegExp(
-    AaptPrefixes.verNamePrefix + AaptPrefixes.quoteRegex
-  ).exec(stdout);
-  const minSdk = new RegExp(
-    AaptPrefixes.sdkPrefix + AaptPrefixes.quoteRegex
-  ).exec(stdout);
-  const permissions = [...stdout.matchAll(/uses-permission: name='(.*)'/g)];
-  const locales = new RegExp(
-    AaptPrefixes.localePrefix + AaptPrefixes.quoteNonLazyRegex
-  ).exec(stdout);
+  try {
+    const { stdout } = await runExec(`${aaptDir}/aapt2 dump badging "${apkPath}"`);
 
-  let localeArray = Array.from(locales?.values() ?? []);
-  if (localeArray.length == 2) {
-    const localesSrc = localeArray[1];
-    localeArray = ["en-US"].concat(localesSrc.split("' '").slice(1));
+    const appPackage = new RegExp(
+      AaptPrefixes.packagePrefix + AaptPrefixes.quoteRegex
+    ).exec(stdout);
+    const versionCode = new RegExp(
+      AaptPrefixes.verCodePrefix + AaptPrefixes.quoteRegex
+    ).exec(stdout);
+    const versionName = new RegExp(
+      AaptPrefixes.verNamePrefix + AaptPrefixes.quoteRegex
+    ).exec(stdout);
+    const minSdk = new RegExp(
+      AaptPrefixes.sdkPrefix + AaptPrefixes.quoteRegex
+    ).exec(stdout);
+    const permissions = [...stdout.matchAll(/uses-permission: name='(.*)'/g)];
+    const locales = new RegExp(
+      AaptPrefixes.localePrefix + AaptPrefixes.quoteNonLazyRegex
+    ).exec(stdout);
+
+    let localeArray = Array.from(locales?.values() ?? []);
+    if (localeArray.length == 2) {
+      const localesSrc = localeArray[1];
+      localeArray = ["en-US"].concat(localesSrc.split("' '").slice(1));
+    }
+
+    if (localeArray.length >= 60) {
+      showMessage(
+        "The bundle apk claims supports for following locales",
+        "Claim for supported locales::\n" +
+        localeArray +
+        "\nIf this release does not support all these locales the release may be rejected" +
+        "\nSee details at https://developer.android.com/guide/topics/resources/multilingual-support#design for configuring the supported locales",
+        "warning"
+      );
+    }
+
+    return {
+      android_package: appPackage?.[1] ?? "",
+      min_sdk: parseInt(minSdk?.[1] ?? "0", 10),
+      version_code: parseInt(versionCode?.[1] ?? "0", 10),
+      version: versionName?.[1] ?? "0",
+      permissions: permissions.flatMap(permission => permission[1]),
+      locales: localeArray
+    };
+  } catch (e) {
+    throw new Error("There was an error parsing your APK. Please ensure you have provided a valid Android tools directory containing AAPT2.");
   }
-
-  if (localeArray.length >= 60) {
-    showMessage(
-      "The bundle apk claims supports for following locales",
-      "Claim for supported locales::\n" +
-      localeArray +
-      "\nIf this release does not support all these locales the release may be rejected" +
-      "\nSee details at https://developer.android.com/guide/topics/resources/multilingual-support#design for configuring the supported locales",
-      "warning"
-    );
-  }
-
-  return {
-    android_package: appPackage?.[1] ?? "",
-    min_sdk: parseInt(minSdk?.[1] ?? "0", 10),
-    version_code: parseInt(versionCode?.[1] ?? "0", 10),
-    version: versionName?.[1] ?? "0",
-    permissions: permissions.flatMap(permission => permission[1]),
-    locales: localeArray
-  };
 };
 
 export const writeToPublishDetails = async ({ publisher, app, release }: SaveToConfigArgs) => {

--- a/packages/cli/src/config/PublishDetails.ts
+++ b/packages/cli/src/config/PublishDetails.ts
@@ -197,11 +197,6 @@ const getAndroidDetails = async (
   aaptDir: string,
   apkPath: string
 ): Promise<AndroidDetails> => {
-  //fs.lstatSync(buildToolsDir).isDirectory()
-  //1. Not a directory
-  //2. Not a diretctory with aapt2
-  //3. Escaping path
-
   try {
     const { stdout } = await runExec(`${aaptDir}/aapt2 dump badging "${apkPath}"`);
 


### PR DESCRIPTION
Addresses all of the comments in #190 the following ways:

- All potential throw errors are contained in the parsing method with appropriate handling/messaging
- Wrap path to APK file in quotes so no error is thrown for paths with spaces
- Updated documentation so publishers know to point at a directory containing AAPT2. We have seen some publishers pointing at tools that don't have it, so we'll make sure they provide an accurate path containing it.