### PR TITLE
Update all publishing calls so they do not check APK contents

### DIFF
--- a/packages/cli/src/CliUtils.ts
+++ b/packages/cli/src/CliUtils.ts
@@ -13,6 +13,10 @@ export class Constants {
   static CLI_VERSION = "0.4.1";
   static CONFIG_FILE_NAME = "config.yaml";
   static DEFAULT_RPC_DEVNET = "https://api.devnet.solana.com";
+
+  static getConfigFilePath = () => {
+    return `${process.cwd()}/${Constants.CONFIG_FILE_NAME}`;
+  };
 }
 
 export const debug = debugModule("CLI");

--- a/packages/cli/src/config/PublishDetails.ts
+++ b/packages/cli/src/config/PublishDetails.ts
@@ -62,9 +62,7 @@ export const loadPublishDetails = async (configPath: string) => {
 export const loadPublishDetailsWithChecks = async (
   buildToolsDir: string | null = null
 ): Promise<PublishDetails> => {
-  const configFilePath = `${process.cwd()}/${Constants.CONFIG_FILE_NAME}`;
-
-  const config = await loadPublishDetails(configFilePath);
+  const config = await loadPublishDetails(Constants.getConfigFilePath());
 
   // We validate that the config is going to have at least one installable asset
   const apkEntry = config.release.files.find(
@@ -269,5 +267,5 @@ export const writeToPublishDetails = async ({ publisher, app, release }: SaveToC
     solana_mobile_dapp_publisher_portal: currentConfig.solana_mobile_dapp_publisher_portal
   };
 
-  fs.writeFileSync(`${process.cwd()}/${Constants.CONFIG_FILE_NAME}`, dump(newConfig));
+  fs.writeFileSync(Constants.getConfigFilePath(), dump(newConfig));
 };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -20,7 +20,7 @@ import boxen from "boxen";
 
 import * as dotenv from "dotenv";
 import { initScaffold } from "./commands/scaffolding/index.js";
-import { loadPublishDetailsWithChecks } from "./config/PublishDetails.js";
+import { loadPublishDetails, loadPublishDetailsWithChecks } from "./config/PublishDetails.js";
 
 dotenv.config();
 
@@ -286,7 +286,7 @@ async function main() {
           await checkForSelfUpdate();
           await checkSubmissionNetwork(url);
 
-          const config = await loadPublishDetailsWithChecks();
+          const config = await loadPublishDetails(Constants.getConfigFilePath());
 
           if (!hasAddressInConfig(config.release) && !releaseMintAddress) {
             throw new Error("Either specify a release mint address in the config file or specify as a CLI argument to this command.")
@@ -357,7 +357,7 @@ async function main() {
           await checkForSelfUpdate();
           await checkSubmissionNetwork(url);
 
-          const config = await loadPublishDetailsWithChecks();
+          const config = await loadPublishDetails(Constants.getConfigFilePath())
 
           if (!hasAddressInConfig(config.release) && !releaseMintAddress) {
             throw new Error("Either specify a release mint address in the config file or specify as a CLI argument to this command.")
@@ -424,7 +424,7 @@ async function main() {
           await checkForSelfUpdate();
           await checkSubmissionNetwork(url);
 
-          const config = await loadPublishDetailsWithChecks();
+          const config = await loadPublishDetails(Constants.getConfigFilePath())
 
           if (!hasAddressInConfig(config.release) && !releaseMintAddress) {
             throw new Error("Either specify a release mint address in the config file or specify as a CLI argument to this command.")
@@ -484,7 +484,7 @@ async function main() {
           await checkForSelfUpdate();
           await checkSubmissionNetwork(url);
 
-          const config = await loadPublishDetailsWithChecks();
+          const config = await loadPublishDetails(Constants.getConfigFilePath())
 
           if (!hasAddressInConfig(config.release) && !releaseMintAddress) {
             throw new Error("Either specify a release mint address in the config file or specify as a CLI argument to this command.")


### PR DESCRIPTION
This affects only the calls that are used for submitting for inclusion into the dApp store. Once things are on-chain, we just need the config file to be loaded (and validated), not the files as well.