### PR TITLE
Update PUBLISHING.md

### DIFF
--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -121,6 +121,7 @@ Release JSON valid!
    ```
 
    _NOTE: this will be repeated each time you have a new version of your dApp to release. The mint address of the latest release is recorded in your configuration file_.
+   > **Warning**: on this step make sure your network is reliable and has a minimum upload speed of 0.25 megabytes per second.
 
 ### Submit your dApp
 


### PR DESCRIPTION
I've added a small warning for people with poor network/bandwidth

![image](https://github.com/solana-mobile/dapp-publishing/assets/125173470/78248407-8011-4462-8a5b-8b71d343d525)
https://discord.com/channels/988649555283308564/1106135716121026590/1106667025406898176

This might save someone in 3rd world countries a lot of time of troubleshooting considering that the error thrown is a bit vague (just a casual "timeout") and the developer could hit a wall while publishing

@creativedrewy feel free to discard this PR or rephrase my sentence as you wish :)