### PR TITLE
Remember last actions.

### DIFF
--- a/packages/cli/src/CliSetup.ts
+++ b/packages/cli/src/CliSetup.ts
@@ -320,15 +320,28 @@ publishCommand
 
         const signer = parseKeypair(keypair);
         if (signer) {
-          await publishSubmitCommand({
-            appMintAddress,
-            releaseMintAddress,
-            signer,
-            url,
-            dryRun,
-            compliesWithSolanaDappStorePolicies,
-            requestorIsAuthorized,
-          });
+          if (hasAddressInConfig(config.lastUpdatedVersionOnStore)) {
+              await publishUpdateCommand({
+                appMintAddress: appMintAddress,
+                releaseMintAddress: releaseMintAddress,
+                signer: signer,
+                url: url,
+                dryRun: dryRun,
+                compliesWithSolanaDappStorePolicies: compliesWithSolanaDappStorePolicies,
+                requestorIsAuthorized: requestorIsAuthorized,
+                critical: false,
+              });
+          } else {
+            await publishSubmitCommand({
+              appMintAddress: appMintAddress,
+              releaseMintAddress: releaseMintAddress,
+              signer: signer,
+              url: url,
+              dryRun: dryRun,
+              compliesWithSolanaDappStorePolicies: compliesWithSolanaDappStorePolicies,
+              requestorIsAuthorized: requestorIsAuthorized,
+            });
+          }
 
           if (dryRun) {
             dryRunSuccessMessage()

--- a/packages/cli/src/commands/create/CreateCliApp.ts
+++ b/packages/cli/src/commands/create/CreateCliApp.ts
@@ -71,6 +71,7 @@ const createAppNft = async (
       }
     }
   }
+  throw new Error("Unable to mint app NFT");
 };
 
 type CreateAppCommandInput = {

--- a/packages/cli/src/commands/create/CreateCliPublisher.ts
+++ b/packages/cli/src/commands/create/CreateCliPublisher.ts
@@ -62,6 +62,7 @@ const createPublisherNft = async (
       }
     }
   }
+  throw new Error("Unable to mint publisher NFT");
 };
 
 export const createPublisherCommand = async ({

--- a/packages/cli/src/config/PublishDetails.ts
+++ b/packages/cli/src/config/PublishDetails.ts
@@ -1,6 +1,8 @@
 import type {
   AndroidDetails,
   App,
+  LastSubmittedVersionOnChain,
+  LastUpdatedVersionOnStore,
   Publisher,
   Release,
   SolanaMobileDappPublisherPortal
@@ -25,6 +27,8 @@ export interface PublishDetails {
   app: App;
   release: Release;
   solana_mobile_dapp_publisher_portal: SolanaMobileDappPublisherPortal;
+  lastSubmittedVersionOnChain: LastSubmittedVersionOnChain
+  lastUpdatedVersionOnStore: LastUpdatedVersionOnStore,
 }
 
 const AaptPrefixes = {
@@ -42,6 +46,8 @@ type SaveToConfigArgs = {
   publisher?: Pick<Publisher, "address">;
   app?: Pick<App, "address">;
   release?: Pick<Release, "address">;
+  lastSubmittedVersionOnChain?: LastSubmittedVersionOnChain;
+  lastUpdatedVersionOnStore?: LastUpdatedVersionOnStore;
 };
 
 const ajv = new Ajv({ strictTuples: false });
@@ -283,7 +289,7 @@ export const extractCertFingerprint = async (aaptDir: string, apkPath: string): 
   }
 }
 
-export const writeToPublishDetails = async ({ publisher, app, release }: SaveToConfigArgs) => {
+export const writeToPublishDetails = async ({ publisher, app, release, lastSubmittedVersionOnChain, lastUpdatedVersionOnStore }: SaveToConfigArgs) => {
   const currentConfig = await loadPublishDetailsWithChecks();
 
   delete currentConfig.publisher.icon;
@@ -302,7 +308,9 @@ export const writeToPublishDetails = async ({ publisher, app, release }: SaveToC
       ...currentConfig.release,
       address: release?.address ?? currentConfig.release.address
     },
-    solana_mobile_dapp_publisher_portal: currentConfig.solana_mobile_dapp_publisher_portal
+    solana_mobile_dapp_publisher_portal: currentConfig.solana_mobile_dapp_publisher_portal,
+    lastSubmittedVersionOnChain: lastSubmittedVersionOnChain ?? currentConfig.lastSubmittedVersionOnChain,
+    lastUpdatedVersionOnStore: lastUpdatedVersionOnStore ?? currentConfig.lastUpdatedVersionOnStore
   };
 
   fs.writeFileSync(Constants.getConfigFilePath(), dump(newConfig, {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -85,3 +85,13 @@ export type SolanaMobileDappPublisherPortal = {
   google_store_package: string;
   testing_instructions: string;
 };
+
+export type LastSubmittedVersionOnChain = {
+  address: string;
+  version_code: number;
+  apk_hash: string;
+}
+
+export type LastUpdatedVersionOnStore = {
+  address: string;
+}


### PR DESCRIPTION
Prevents developers from minting bad release NFTs such as those with 
1. same version code and different apk. 
2. Materially same nft as previous ones. (same apk hash)

Manages the store update process by preventing developers from 
1. Submitting same request to update multiple times on store.
2. Submitting app update as new app.

This would basically take effect from the second release after taking this update. First release would only populate the data in the config.yaml file. 