### PR TITLE
Support minVersionSdk for android build tools

### DIFF
--- a/packages/cli/src/config/PublishDetails.ts
+++ b/packages/cli/src/config/PublishDetails.ts
@@ -38,7 +38,7 @@ const AaptPrefixes = {
   packagePrefix: "package: name=",
   verCodePrefix: "versionCode=",
   verNamePrefix: "versionName=",
-  sdkPrefix: "sdkVersion:",
+  sdkPrefix: "(?:minSdk|sdk)Version:",
   debuggableApkPrefix: "application-debuggable",
   localePrefix: "locales: ",
 };


### PR DESCRIPTION
build tool version 34 and below prints this 
```
sdkVersion:'22'
```

while build tool version 35 prints this
```
minSdkVersion:'22'
```
on the same apk. 

This change fixes the parsing for support between the 2 variants. 