### PR TITLE
Update permission matching logic

### DIFF
--- a/packages/cli/src/config/PublishDetails.ts
+++ b/packages/cli/src/config/PublishDetails.ts
@@ -272,7 +272,7 @@ const getAndroidDetails = async (
     const minSdk = new RegExp(
       AaptPrefixes.sdkPrefix + AaptPrefixes.quoteRegex
     ).exec(stdout);
-    const permissions = [...stdout.matchAll(/uses-permission: name='(.*)'/g)].flatMap(permission => permission[1]);
+    const permissions = [...stdout.matchAll(/(?:uses-permission|uses-permission-sdk-23): name='([^']*)'/g)].flatMap(permission => permission[1]);
     const locales = new RegExp(
       AaptPrefixes.localePrefix + AaptPrefixes.quoteNonLazyRegex
     ).exec(stdout);


### PR DESCRIPTION
1. Include sdk23 permissions
2. Remove maxSdk filter from permissions which is not parsed correctly on clients.