### PR TITLE
Change commitment level to confirmed.

### DIFF
--- a/packages/cli/src/commands/create/CreateCliApp.ts
+++ b/packages/cli/src/commands/create/CreateCliApp.ts
@@ -57,6 +57,7 @@ const createAppNft = async (
         publisher,
         mintAddress,
       ], {
+        commitment: "confirmed",
         minContextSlot: blockhash.context.slot
       });
       return { appAddress: mintAddress.publicKey.toBase58(), transactionSignature: txSig };
@@ -91,7 +92,13 @@ export const createAppCommand = async ({
   storageParams,
   priorityFeeLamports = Constants.DEFAULT_PRIORITY_FEE,
 }: CreateAppCommandInput) => {
-  const connection = new Connection(url);
+  const connection = new Connection(
+    url,
+    {
+      commitment: "confirmed",
+      disableRetryOnRateLimit: true,
+    }
+  );
 
   const { app: appDetails, publisher: publisherDetails } =
     await loadPublishDetailsWithChecks();

--- a/packages/cli/src/commands/create/CreateCliPublisher.ts
+++ b/packages/cli/src/commands/create/CreateCliPublisher.ts
@@ -48,6 +48,7 @@ const createPublisherNft = async (
         publisher,
         mintAddress,
       ], {
+        commitment: "confirmed",
         minContextSlot: blockhash.context.slot
       });
       return { publisherAddress: mintAddress.publicKey.toBase58(), transactionSignature: txSig};
@@ -78,7 +79,13 @@ export const createPublisherCommand = async ({
   storageParams: string;
   priorityFeeLamports: number;
 }) => {
-  const connection = new Connection(url);
+  const connection = new Connection(
+    url,
+    {
+      commitment: "confirmed",
+      disableRetryOnRateLimit: true,
+    }
+  );
 
   const { publisher: publisherDetails } = await loadPublishDetailsWithChecks();
 

--- a/packages/cli/src/commands/create/CreateCliRelease.ts
+++ b/packages/cli/src/commands/create/CreateCliRelease.ts
@@ -77,6 +77,7 @@ const createReleaseNft = async ({
         publisher,
         releaseMintAddress,
       ], {
+        commitment: "confirmed",
         minContextSlot: blockhash.context.slot,
       });
       return { releaseAddress: releaseMintAddress.publicKey.toBase58(), transactionSignature: txSig };
@@ -103,7 +104,13 @@ export const createReleaseCommand = async ({
   storageParams,
   priorityFeeLamports = Constants.DEFAULT_PRIORITY_FEE,
 }: CreateReleaseCommandInput) => {
-  const connection = new Connection(url);
+  const connection = new Connection(
+    url,
+    {
+      commitment: "confirmed",
+      disableRetryOnRateLimit: true,
+    }
+  );
 
   const config = await loadPublishDetailsWithChecks(buildToolsPath);
 


### PR DESCRIPTION
disable retry on rate limit - enabled

Default was to max which took a long time which constantly checking the RPC causing rate limits on free version of helius