### PR TITLE
Add initial alpha testing support

### DIFF
--- a/example/config.yaml
+++ b/example/config.yaml
@@ -57,5 +57,3 @@ solana_mobile_dapp_publisher_portal:
       comment: Employe#1 genesis token
     - address: G65S4B3RkFpPAt9CwY4cZXptNSkTS6c8hFW1m89GCuB1
       comment: Employe#2 genesis token
-lastUpdatedVersionOnStore:
-  address: DQTYHFQs2ivTRzWEXmoyGtYd8y12uFicDqDjbrPpE78Q

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -52,4 +52,10 @@ release:
 solana_mobile_dapp_publisher_portal:
   google_store_package: com.solanamobile.cutekitten.gps
   testing_instructions: Here are some steps informing Solana Mobile of how to test this dapp. You can specify multiple lines of instructions. For example, if a login is needed, you would add those details here.
-  #alpha_testers: 3tgkMfug2gs82sy2wexQjMkR12JzFcX9rSLd9yM9m38g,G65S4B3RkFpPAt9CwY4cZXptNSkTS6c8hFW1m89GCuB1 -- specify your own
+  alpha_testers:
+    - address: 3tgkMfug2gs82sy2wexQjMkR12JzFcX9rSLd9yM9m38g
+      comment: Employe#1 genesis token
+    - address: G65S4B3RkFpPAt9CwY4cZXptNSkTS6c8hFW1m89GCuB1
+      comment: Employe#2 genesis token
+lastUpdatedVersionOnStore:
+  address: DQTYHFQs2ivTRzWEXmoyGtYd8y12uFicDqDjbrPpE78Q

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -52,3 +52,4 @@ release:
 solana_mobile_dapp_publisher_portal:
   google_store_package: com.solanamobile.cutekitten.gps
   testing_instructions: Here are some steps informing Solana Mobile of how to test this dapp. You can specify multiple lines of instructions. For example, if a login is needed, you would add those details here.
+  #alpha_testers: 3tgkMfug2gs82sy2wexQjMkR12JzFcX9rSLd9yM9m38g,G65S4B3RkFpPAt9CwY4cZXptNSkTS6c8hFW1m89GCuB1 -- specify your own

--- a/packages/cli/src/CliSetup.ts
+++ b/packages/cli/src/CliSetup.ts
@@ -303,6 +303,7 @@ publishCommand
     "-d, --dry-run",
     "Flag for dry run. Doesn't submit the request to the publisher portal."
   )
+  .option("-l, --alpha", "Flag to mark the submission as alpha test.")
   .action(
     async ({
              appMintAddress,
@@ -312,6 +313,7 @@ publishCommand
              compliesWithSolanaDappStorePolicies,
              requestorIsAuthorized,
              dryRun,
+             alpha,
            }) => {
       await tryWithErrorMessage(async () => {
         await checkForSelfUpdate();
@@ -335,6 +337,7 @@ publishCommand
                 compliesWithSolanaDappStorePolicies: compliesWithSolanaDappStorePolicies,
                 requestorIsAuthorized: requestorIsAuthorized,
                 critical: false,
+                alphaTest: alpha,
               });
           } else {
             await publishSubmitCommand({
@@ -345,6 +348,7 @@ publishCommand
               dryRun: dryRun,
               compliesWithSolanaDappStorePolicies: compliesWithSolanaDappStorePolicies,
               requestorIsAuthorized: requestorIsAuthorized,
+              alphaTest: alpha,
             });
           }
 
@@ -389,6 +393,7 @@ publishCommand
     "-d, --dry-run",
     "Flag for dry run. Doesn't submit the request to the publisher portal."
   )
+  .option("-l, --alpha", "Flag to mark the submission as alpha test.")
   .action(
     async ({
              appMintAddress,
@@ -399,6 +404,7 @@ publishCommand
              requestorIsAuthorized,
              critical,
              dryRun,
+             alpha,
            }) => {
       await tryWithErrorMessage(async () => {
         await checkForSelfUpdate();
@@ -421,6 +427,7 @@ publishCommand
             compliesWithSolanaDappStorePolicies,
             requestorIsAuthorized,
             critical,
+            alphaTest: alpha,
           });
 
           if (dryRun) {

--- a/packages/cli/src/CliSetup.ts
+++ b/packages/cli/src/CliSetup.ts
@@ -11,6 +11,7 @@ import {
   checkForSelfUpdate,
   checkSubmissionNetwork,
   Constants,
+  alphaAppSubmissionMessage,
   dryRunSuccessMessage,
   generateNetworkSuffix,
   parseKeypair,
@@ -325,6 +326,10 @@ publishCommand
           throw new Error("Either specify a release mint address in the config file or specify as a CLI argument to this command.")
         }
 
+        if (alpha) {
+          alphaAppSubmissionMessage()
+        }
+
         const signer = parseKeypair(keypair);
         if (signer) {
           if (config.lastUpdatedVersionOnStore != null && config.lastSubmittedVersionOnChain.address != null) {
@@ -414,6 +419,10 @@ publishCommand
 
         if (!hasAddressInConfig(config.release) && !releaseMintAddress) {
           throw new Error("Either specify a release mint address in the config file or specify as a CLI argument to this command.")
+        }
+
+        if (alpha) {
+          alphaAppSubmissionMessage()
         }
 
         const signer = parseKeypair(keypair);

--- a/packages/cli/src/CliUtils.ts
+++ b/packages/cli/src/CliUtils.ts
@@ -143,6 +143,15 @@ export const dryRunSuccessMessage = () => {
   showMessage("Dry run", "Dry run was successful", "standard")
 }
 
+export const alphaAppSubmissionMessage = () => {
+  showMessage(
+    "Alpha release", 
+    "Apps are not auto-reviewed on alpha track and are meant for internal testing only.\n" +
+    "Reach out to the mobile team contact to upgrade your alpha app to release.",
+    "warning"
+  )
+}
+
 export const showNetworkWarningIfApplicable = (rpcUrl: string) => {
   if (isDevnet(rpcUrl)) {
     showMessage("Devnet Mode", "Running on Devnet", "warning")

--- a/packages/cli/src/CliUtils.ts
+++ b/packages/cli/src/CliUtils.ts
@@ -146,8 +146,8 @@ export const dryRunSuccessMessage = () => {
 export const alphaAppSubmissionMessage = () => {
   showMessage(
     "Alpha release", 
-    "Apps are not auto-reviewed on alpha track and are meant for internal testing only.\n" +
-    "Reach out to the mobile team contact to upgrade your alpha app to release.",
+    "Alpha releases are not reviewed on dApp store and are meant for internal testing only.\n" +
+    "Run the `npx dapp-store publish submit ...` command again without the `--alpha` param to publish the app",
     "warning"
   )
 }

--- a/packages/cli/src/commands/publish/PublishCliSubmit.ts
+++ b/packages/cli/src/commands/publish/PublishCliSubmit.ts
@@ -14,6 +14,7 @@ type PublishSubmitCommandInput = {
   dryRun: boolean;
   compliesWithSolanaDappStorePolicies: boolean;
   requestorIsAuthorized: boolean;
+  alphaTest?: boolean;
 };
 
 export const publishSubmitCommand = async ({
@@ -24,6 +25,7 @@ export const publishSubmitCommand = async ({
   dryRun = false,
   compliesWithSolanaDappStorePolicies = false,
   requestorIsAuthorized = false,
+  alphaTest
 }: PublishSubmitCommandInput) => {
   showMessage(
     `Publishing Estimates`,
@@ -74,6 +76,7 @@ export const publishSubmitCommand = async ({
       solanaMobileDappPublisherPortalDetails,
       compliesWithSolanaDappStorePolicies,
       requestorIsAuthorized,
+      alphaTest,
     },
     dryRun
   );

--- a/packages/cli/src/commands/publish/PublishCliSubmit.ts
+++ b/packages/cli/src/commands/publish/PublishCliSubmit.ts
@@ -85,8 +85,10 @@ export const publishSubmitCommand = async ({
     dryRun
   );
 
-  await writeToPublishDetails(
-    {
-      lastUpdatedVersionOnStore: { address: releaseAddr }
-    });
+  if (!alphaTest) {
+    await writeToPublishDetails(
+      {
+        lastUpdatedVersionOnStore: { address: releaseAddr }
+      });
+  }
 };

--- a/packages/cli/src/commands/publish/PublishCliSubmit.ts
+++ b/packages/cli/src/commands/publish/PublishCliSubmit.ts
@@ -54,6 +54,10 @@ export const publishSubmitCommand = async ({
     lastUpdatedVersionOnStore: lastUpdatedVersionOnStore,
   } = await loadPublishDetailsWithChecks();
 
+  if (alphaTest && solanaMobileDappPublisherPortalDetails.alpha_testers == undefined) {
+    throw new Error(`Alpha test submission without specifying any testers.\nAdd field alpha_testers in your 'config.yaml' file.`)
+  }
+
   const sign = ((buf: Buffer) =>
     nacl.sign(buf, signer.secretKey)) as SignWithPublisherKeypair;
 

--- a/packages/cli/src/commands/publish/PublishCliUpdate.ts
+++ b/packages/cli/src/commands/publish/PublishCliUpdate.ts
@@ -14,6 +14,7 @@ type PublishUpdateCommandInput = {
   compliesWithSolanaDappStorePolicies: boolean;
   requestorIsAuthorized: boolean;
   critical: boolean;
+  alphaTest?: boolean;
 };
 
 export const publishUpdateCommand = async ({
@@ -25,6 +26,7 @@ export const publishUpdateCommand = async ({
   compliesWithSolanaDappStorePolicies = false,
   requestorIsAuthorized = false,
   critical = false,
+  alphaTest,
 }: PublishUpdateCommandInput) => {
 
   showMessage(
@@ -83,6 +85,7 @@ export const publishUpdateCommand = async ({
       compliesWithSolanaDappStorePolicies,
       requestorIsAuthorized,
       criticalUpdate: critical,
+      alphaTest,
     },
     dryRun
   );

--- a/packages/cli/src/commands/publish/PublishCliUpdate.ts
+++ b/packages/cli/src/commands/publish/PublishCliUpdate.ts
@@ -93,8 +93,10 @@ export const publishUpdateCommand = async ({
     },
     dryRun
   );
-  await writeToPublishDetails(
-    {
-      lastUpdatedVersionOnStore: { address: releaseAddr }
-    });
+  if (!alphaTest) {
+    await writeToPublishDetails(
+      {
+        lastUpdatedVersionOnStore: { address: releaseAddr }
+      });
+  }
 };

--- a/packages/cli/src/commands/publish/PublishCliUpdate.ts
+++ b/packages/cli/src/commands/publish/PublishCliUpdate.ts
@@ -62,6 +62,10 @@ export const publishUpdateCommand = async ({
     lastUpdatedVersionOnStore: lastUpdatedVersionOnStore
   } = await loadPublishDetailsWithChecks();
 
+  if (alphaTest && solanaMobileDappPublisherPortalDetails.alpha_testers == undefined) {
+    throw new Error(`Alpha test submission without specifying any testers.\nAdd field alpha_testers in your 'config.yaml' file.`)
+  }
+
   const sign = ((buf: Buffer) =>
     nacl.sign(buf, signer.secretKey)) as SignWithPublisherKeypair;
 

--- a/packages/cli/src/config/PublishDetails.ts
+++ b/packages/cli/src/config/PublishDetails.ts
@@ -20,6 +20,7 @@ import util from "util";
 import { imageSize } from "image-size";
 import { exec } from "child_process";
 import getVideoDimensions from "get-video-dimensions";
+import { PublicKey } from "@solana/web3.js";
 
 const runImgSize = util.promisify(imageSize);
 const runExec = util.promisify(exec);
@@ -176,6 +177,17 @@ export const loadPublishDetailsWithChecks = async (
 
     if (!pkgCompare?.length) {
       throw new Error("Please provide a valid Google store package name in the Publisher Portal section of your configuration file.");
+    }
+  }
+
+  const { alpha_testers } = config.solana_mobile_dapp_publisher_portal;
+  if (alpha_testers !== undefined) {
+    for (const wallet of alpha_testers.split(",")) {
+      try {
+        void new PublicKey(wallet);
+      } catch (e: unknown) {
+        throw new Error(`invalid alpha tester wallet <${wallet}>`);
+      }
     }
   }
 

--- a/packages/cli/src/config/PublishDetails.ts
+++ b/packages/cli/src/config/PublishDetails.ts
@@ -181,16 +181,18 @@ export const loadPublishDetailsWithChecks = async (
   }
 
   const alpha_testers = config.solana_mobile_dapp_publisher_portal.alpha_testers;
-  for (const wallet of alpha_testers) {
-    try {
-      void new PublicKey(wallet.address);
-    } catch (e: unknown) {
-      throw new Error(`invalid alpha tester wallet address <${wallet}>`);
+  if (alpha_testers !== undefined) {
+    for (const wallet of alpha_testers) {
+      try {
+        void new PublicKey(wallet.address);
+      } catch (e: unknown) {
+        throw new Error(`invalid alpha tester wallet address <${wallet}>`);
+      }
     }
-  }
 
-  if (alpha_testers.size > 10) {
-    throw new Error(`Alpha testers are limited to 10 per app submission`);
+    if (alpha_testers.size > 10) {
+      throw new Error(`Alpha testers are limited to 10 per app submission`);
+    }
   }
 
   return config;

--- a/packages/cli/src/config/PublishDetails.ts
+++ b/packages/cli/src/config/PublishDetails.ts
@@ -180,15 +180,17 @@ export const loadPublishDetailsWithChecks = async (
     }
   }
 
-  const { alpha_testers } = config.solana_mobile_dapp_publisher_portal;
-  if (alpha_testers !== undefined) {
-    for (const wallet of alpha_testers.split(",")) {
-      try {
-        void new PublicKey(wallet);
-      } catch (e: unknown) {
-        throw new Error(`invalid alpha tester wallet <${wallet}>`);
-      }
+  const alpha_testers = config.solana_mobile_dapp_publisher_portal.alpha_testers;
+  for (const wallet of alpha_testers) {
+    try {
+      void new PublicKey(wallet.address);
+    } catch (e: unknown) {
+      throw new Error(`invalid alpha tester wallet address <${wallet}>`);
     }
+  }
+
+  if (alpha_testers.size > 10) {
+    throw new Error(`Alpha testers are limited to 10 per app submission`);
   }
 
   return config;

--- a/packages/cli/src/prebuild_schema/publishing_source.yaml
+++ b/packages/cli/src/prebuild_schema/publishing_source.yaml
@@ -52,4 +52,8 @@ solana_mobile_dapp_publisher_portal:
   google_store_package: <<ANDROID_PACKAGE_NAME_OF_GOOGLE_PLAY_STORE_VERSION_IF_DIFFERENT>>
   testing_instructions: >-
     <<TESTING_INSTRUCTIONS>>
-  alpha_testers: <<COMMA_SEPARATED_LIST_OF_WALLETS>>
+  alpha_testers: 
+    - address: <<genesis token wallet address>>
+      comment: <<Optional. For internal use only>>
+    - address: <<genesis token wallet address>>
+      comment: <<Optional. For internal use only>>

--- a/packages/cli/src/prebuild_schema/publishing_source.yaml
+++ b/packages/cli/src/prebuild_schema/publishing_source.yaml
@@ -52,3 +52,4 @@ solana_mobile_dapp_publisher_portal:
   google_store_package: <<ANDROID_PACKAGE_NAME_OF_GOOGLE_PLAY_STORE_VERSION_IF_DIFFERENT>>
   testing_instructions: >-
     <<TESTING_INSTRUCTIONS>>
+  alpha_testers: <<COMMA_SEPARATED_LIST_OF_WALLETS>>

--- a/packages/core/src/publish/PublishCoreSubmit.ts
+++ b/packages/core/src/publish/PublishCoreSubmit.ts
@@ -111,11 +111,11 @@ const createSubmitRequest = async (
     );
   }
 
-  if (solanaMobileDappPublisherPortalDetails.alpha_testers !== undefined) {
+  if (solanaMobileDappPublisherPortalDetails.alpha_testers.length > 0) {
     request.fields.push({
       objectTypeId: TICKET_OBJECT_ID,
       name: TICKET_PROPERTY_ALPHA_TESTERS,
-      value: solanaMobileDappPublisherPortalDetails.alpha_testers,
+      value: solanaMobileDappPublisherPortalDetails.alpha_testers.map(tester => tester.address).toString(),
     });
   }
 

--- a/packages/core/src/publish/PublishCoreSubmit.ts
+++ b/packages/core/src/publish/PublishCoreSubmit.ts
@@ -111,7 +111,7 @@ const createSubmitRequest = async (
     );
   }
 
-  if (solanaMobileDappPublisherPortalDetails.alpha_testers.length > 0) {
+  if (solanaMobileDappPublisherPortalDetails.alpha_testers !== undefined && solanaMobileDappPublisherPortalDetails.alpha_testers.length > 0) {
     request.fields.push({
       objectTypeId: TICKET_OBJECT_ID,
       name: TICKET_PROPERTY_ALPHA_TESTERS,

--- a/packages/core/src/publish/PublishCoreSubmit.ts
+++ b/packages/core/src/publish/PublishCoreSubmit.ts
@@ -8,6 +8,8 @@ import {
   CONTACT_PROPERTY_WEBSITE,
   submitRequestToSolanaDappPublisherPortal,
   TICKET_OBJECT_ID,
+  TICKET_PROPERTY_ALPHA_TEST,
+  TICKET_PROPERTY_ALPHA_TESTERS,
   TICKET_PROPERTY_ATTESTATION_PAYLOAD,
   TICKET_PROPERTY_AUTHORIZED_REQUEST,
   TICKET_PROPERTY_DAPP_COLLECTION_ACCOUNT_ADDRESS,
@@ -28,7 +30,8 @@ const createSubmitRequest = async (
   publisherDetails: Publisher,
   solanaMobileDappPublisherPortalDetails: SolanaMobileDappPublisherPortal,
   compliesWithSolanaDappStorePolicies: boolean,
-  requestorIsAuthorized: boolean
+  requestorIsAuthorized: boolean,
+  alphaTest?: boolean
 ) => {
   const { attestationPayload, requestUniqueId } = await createAttestationPayload(connection, sign);
 
@@ -90,6 +93,14 @@ const createSubmitRequest = async (
     });
   }
 
+  if (alphaTest) {
+    request.fields.push({
+      objectTypeId: TICKET_OBJECT_ID,
+      name: TICKET_PROPERTY_ALPHA_TEST,
+      value: true,
+    });
+  }
+
   if (solanaMobileDappPublisherPortalDetails.testing_instructions !== undefined) {
     request.fields.push(
       {
@@ -98,6 +109,14 @@ const createSubmitRequest = async (
         value: solanaMobileDappPublisherPortalDetails.testing_instructions
       },
     );
+  }
+
+  if (solanaMobileDappPublisherPortalDetails.alpha_testers !== undefined) {
+    request.fields.push({
+      objectTypeId: TICKET_OBJECT_ID,
+      name: TICKET_PROPERTY_ALPHA_TESTERS,
+      value: solanaMobileDappPublisherPortalDetails.alpha_testers,
+    });
   }
 
   return request;
@@ -110,6 +129,7 @@ export type PublishSubmitInput = {
   solanaMobileDappPublisherPortalDetails: SolanaMobileDappPublisherPortal;
   compliesWithSolanaDappStorePolicies: boolean;
   requestorIsAuthorized: boolean;
+  alphaTest?: boolean;
 };
 
 export const publishSubmit = async (
@@ -121,6 +141,7 @@ export const publishSubmit = async (
     solanaMobileDappPublisherPortalDetails,
     compliesWithSolanaDappStorePolicies,
     requestorIsAuthorized,
+    alphaTest,
   } : PublishSubmitInput,
   dryRun: boolean,
 ) => {
@@ -132,7 +153,9 @@ export const publishSubmit = async (
     publisherDetails,
     solanaMobileDappPublisherPortalDetails,
     compliesWithSolanaDappStorePolicies,
-    requestorIsAuthorized);
+    requestorIsAuthorized,
+    alphaTest
+  );
 
   return submitRequestToSolanaDappPublisherPortal(submitRequest, URL_FORM_SUBMIT, dryRun);
 };

--- a/packages/core/src/publish/PublishCoreUpdate.ts
+++ b/packages/core/src/publish/PublishCoreUpdate.ts
@@ -8,6 +8,8 @@ import {
   CONTACT_PROPERTY_WEBSITE,
   submitRequestToSolanaDappPublisherPortal,
   TICKET_OBJECT_ID,
+  TICKET_PROPERTY_ALPHA_TEST,
+  TICKET_PROPERTY_ALPHA_TESTERS,
   TICKET_PROPERTY_ATTESTATION_PAYLOAD,
   TICKET_PROPERTY_AUTHORIZED_REQUEST,
   TICKET_PROPERTY_CRITICAL_UPDATE,
@@ -29,7 +31,8 @@ const createUpdateRequest = async (
   solanaMobileDappPublisherPortalDetails: SolanaMobileDappPublisherPortal,
   compliesWithSolanaDappStorePolicies: boolean,
   requestorIsAuthorized: boolean,
-  criticalUpdate: boolean
+  criticalUpdate: boolean,
+  alphaTest?: boolean
 ) => {
   const { attestationPayload, requestUniqueId } = await createAttestationPayload(connection, sign);
 
@@ -93,6 +96,14 @@ const createUpdateRequest = async (
     );
   }
 
+  if (alphaTest) {
+    request.fields.push({
+      objectTypeId: TICKET_OBJECT_ID,
+      name: TICKET_PROPERTY_ALPHA_TEST,
+      value: true,
+    });
+  }
+
   if (solanaMobileDappPublisherPortalDetails.testing_instructions !== undefined) {
     request.fields.push(
       {
@@ -101,6 +112,14 @@ const createUpdateRequest = async (
         value: solanaMobileDappPublisherPortalDetails.testing_instructions
       }
     );
+  }
+
+  if (solanaMobileDappPublisherPortalDetails.alpha_testers !== undefined) {
+    request.fields.push({
+      objectTypeId: TICKET_OBJECT_ID,
+      name: TICKET_PROPERTY_ALPHA_TESTERS,
+      value: solanaMobileDappPublisherPortalDetails.alpha_testers,
+    });
   }
 
   return request;
@@ -114,6 +133,7 @@ export type PublishUpdateInput = {
   compliesWithSolanaDappStorePolicies: boolean;
   requestorIsAuthorized: boolean;
   criticalUpdate: boolean;
+  alphaTest?: boolean;
 };
 
 export const publishUpdate = async (
@@ -126,6 +146,7 @@ export const publishUpdate = async (
     compliesWithSolanaDappStorePolicies,
     requestorIsAuthorized,
     criticalUpdate,
+    alphaTest,
   } : PublishUpdateInput,
   dryRun: boolean,
 ) => {
@@ -138,7 +159,9 @@ export const publishUpdate = async (
     solanaMobileDappPublisherPortalDetails,
     compliesWithSolanaDappStorePolicies,
     requestorIsAuthorized,
-    criticalUpdate);
+    criticalUpdate,
+    alphaTest
+  );
 
   return submitRequestToSolanaDappPublisherPortal(updateRequest, URL_FORM_UPDATE, dryRun);
 };

--- a/packages/core/src/publish/PublishCoreUpdate.ts
+++ b/packages/core/src/publish/PublishCoreUpdate.ts
@@ -114,11 +114,11 @@ const createUpdateRequest = async (
     );
   }
 
-  if (solanaMobileDappPublisherPortalDetails.alpha_testers !== undefined) {
+  if (solanaMobileDappPublisherPortalDetails.alpha_testers.length > 0) {
     request.fields.push({
       objectTypeId: TICKET_OBJECT_ID,
       name: TICKET_PROPERTY_ALPHA_TESTERS,
-      value: solanaMobileDappPublisherPortalDetails.alpha_testers,
+      value: solanaMobileDappPublisherPortalDetails.alpha_testers.map(tester => tester.address).toString(),
     });
   }
 

--- a/packages/core/src/publish/PublishCoreUpdate.ts
+++ b/packages/core/src/publish/PublishCoreUpdate.ts
@@ -114,7 +114,7 @@ const createUpdateRequest = async (
     );
   }
 
-  if (solanaMobileDappPublisherPortalDetails.alpha_testers.length > 0) {
+  if (solanaMobileDappPublisherPortalDetails.alpha_testers !== undefined && solanaMobileDappPublisherPortalDetails.alpha_testers.length > 0) {
     request.fields.push({
       objectTypeId: TICKET_OBJECT_ID,
       name: TICKET_PROPERTY_ALPHA_TESTERS,

--- a/packages/core/src/publish/dapp_publisher_portal.ts
+++ b/packages/core/src/publish/dapp_publisher_portal.ts
@@ -18,6 +18,8 @@ export const TICKET_PROPERTY_GOOGLE_PLAY_STORE_PACKAGE_NAME = "google_play_store
 export const TICKET_PROPERTY_POLICY_COMPLIANT = "complies_with_solana_dapp_store_policies"; // boolean
 export const TICKET_PROPERTY_REQUEST_UNIQUE_ID = "request_unique_id"; // string (32 base-10 digits)
 export const TICKET_PROPERTY_TESTING_INSTRUCTIONS = "testing_instructions"; // string
+export const TICKET_PROPERTY_ALPHA_TEST = "alpha_test"; // boolean
+export const TICKET_PROPERTY_ALPHA_TESTERS = "alpha_testers"; // string
 
 export const FORM_SUBMIT = "1464247f-6804-46e1-8114-952f372daa81";
 export const FORM_UPDATE = "87b4cbe7-957f-495c-a132-8b789678883d";

--- a/packages/core/src/publish/dapp_publisher_portal.ts
+++ b/packages/core/src/publish/dapp_publisher_portal.ts
@@ -48,7 +48,23 @@ export const submitRequestToSolanaDappPublisherPortal = async (
   if (!dryRun) {
     await axios(config)
       .then((response) => {
-        console.info(`dApp publisher portal response:`, response.data);
+        const isAlphaObject = request.fields.find((obj: { objectTypeId: string, name: string; value: string}) => {
+          return obj.name === TICKET_PROPERTY_ALPHA_TEST
+        })
+
+        if (isAlphaObject !== undefined && isAlphaObject.value) {
+          const requestUniqueId = request.fields.find((obj: { objectTypeId: string, name: string; value: string}) => {
+            return obj.name === TICKET_PROPERTY_REQUEST_UNIQUE_ID
+          }).value
+          console.log(
+            `Your alpha submission has been received.\n` +
+            `It will not be reviewed or published to users.\n` + 
+            `Use nonce '${requestUniqueId}' to launch alpha app.\n` + 
+            `This can only be used on devices for which the genesis token was listed in your 'config.yaml'`
+          )
+        } else {
+          console.info(`dApp publisher portal response:`, response.data);
+        }
       })
       .catch((error) => {
         if (error.response) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -84,6 +84,7 @@ export type Release = {
 export type SolanaMobileDappPublisherPortal = {
   google_store_package: string;
   testing_instructions: string;
+  alpha_testers?: string;
 };
 
 export type LastSubmittedVersionOnChain = {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -81,10 +81,15 @@ export type Release = {
   };
 };
 
+export type AlphaTester = {
+  address: string;
+  comment: string;
+}
+
 export type SolanaMobileDappPublisherPortal = {
   google_store_package: string;
   testing_instructions: string;
-  alpha_testers?: string;
+  alpha_testers: AlphaTester[];
 };
 
 export type LastSubmittedVersionOnChain = {


### PR DESCRIPTION
Add options to support alpha testing.

- `--alpha` - flag marks the submission as an alpha test

A new option `alpha_testers` added to the `config.yaml` file. Allows specifying a set of genesis token holders permitted to participate in alpha testing of the dApp.
