### PR TITLE
chore: update crypto-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
   "pnpm": {
     "patchedDependencies": {
       "@solana/web3.js@1.92.1": "patches/@solana__web3.js@1.92.1.patch"
+    },
+    "overrides": {
+      "crypto-js": "4.2.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  crypto-js: 4.2.0
+
 patchedDependencies:
   '@solana/web3.js@1.92.1':
     hash: 3d172757e2e9b7529303dc540a82fd53a0f5371eda4cd28352972cca1b72e97e
@@ -2052,8 +2055,8 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  crypto-js@3.3.0:
-    resolution: {integrity: sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q==}
+  crypto-js@4.2.0:
+    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
 
   crypto-random-string@4.0.0:
     resolution: {integrity: sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==}
@@ -7524,7 +7527,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  crypto-js@3.3.0: {}
+  crypto-js@4.2.0: {}
 
   crypto-random-string@4.0.0:
     dependencies:
@@ -9164,7 +9167,7 @@ snapshots:
     dependencies:
       bignumber.js: 9.1.2
       buffer-reverse: 1.0.1
-      crypto-js: 3.3.0
+      crypto-js: 4.2.0
       treeify: 1.1.0
       web3-utils: 1.10.4
 


### PR DESCRIPTION
Override `crypto-js` version
Current version has [critical vulnerability](https://github.com/advisories/GHSA-xwcq-pm8m-c4vf)

Partly addresses #238 