### PR TITLE
Preview command added - Looking for feedback

### DIFF
--- a/packages/cli/src/CliSetup.ts
+++ b/packages/cli/src/CliSetup.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { validateCommand } from "./commands/index.js";
+import { previewCommand } from "./commands/index.js";
 import { createAppCommand, createPublisherCommand, createReleaseCommand } from "./commands/create/index.js";
 import {
   publishRemoveCommand,
@@ -270,6 +271,13 @@ mainCli
       }
     });
   });
+
+const prevCommand = mainCli
+  .command("preview")
+  .description(
+    "Preview what the app looks like in the Solana Mobile dApp-store"
+  )
+  .action(previewCommand);
 
 const publishCommand = mainCli
   .command("publish")

--- a/packages/cli/src/commands/PreviewCommand.ts
+++ b/packages/cli/src/commands/PreviewCommand.ts
@@ -1,0 +1,119 @@
+import yaml, { dump } from "js-yaml";
+import { readFile } from 'fs/promises';
+import fs from "fs";
+import path from "path";
+import { JSDOM } from "jsdom";
+
+/*TODO : Add template html of the appstore page - done
+ * Add template tags in html - done
+ * Icon and banner - done
+ * screenshots, demo and feature image - done
+ * Run webserver and serve the html
+ * Auto open the preview
+ */
+
+interface Media {
+  purpose: string;
+  uri: string;
+}
+
+interface FileEntry {
+  purpose: string;
+  uri: string;
+}
+
+interface CatalogEntry {
+  name: string;
+  short_description: string;
+  long_description: string;
+  new_in_version: string;
+  saga_features: string;
+}
+
+interface AlphaTester {
+  address: string;
+  comment?: string;
+}
+
+interface Config {
+  publisher: {
+    name: string;
+    address: string;
+    website: string;
+    email: string;
+    media: Media[];
+  };
+  app: {
+    name: string;
+    address: string;
+    android_package: string;
+    urls: {
+      license_url: string;
+      copyright_url: string;
+      privacy_policy_url: string;
+      website: string;
+    };
+    media: Media[];
+  };
+  release: {
+    address: string;
+    media: Media[];
+    files: FileEntry[];
+    catalog: {
+      'en-US': CatalogEntry;
+    };
+  };
+  solana_mobile_dapp_publisher_portal: {
+    google_store_package: string;
+    testing_instructions: string;
+    alpha_testers: AlphaTester[];
+  };
+}
+
+function readData() {
+  try {
+  const doc = yaml.load(fs.readFileSync("config.yaml", "utf-8"));
+  return doc;
+  } catch(err) {
+  console.error("Error loading config file.")
+  return null;
+  }
+}
+
+function fillTemplate(template: string, data: Record<string, string>): string {
+  let result = new JSDOM(template);
+  //For screenshots/demo images
+  const purposesList = [ "screenshot", "video" ]
+  result.window.document.getElementById("app-title").textContent = data.app.name;
+  result.window.document.getElementById("app-developer").textContent = data.publisher.name;
+  result.window.document.getElementById("description").textContent = data.release.catalog["en-US"].short_description;
+  result.window.document.getElementById("app-icon").innerHTML = `<img src=${data.app.media[0].uri} >`;
+  result.window.document.getElementById("banner").innerHTML = `<img src=${data.release.media.find(m => m.purpose === "banner").uri} >`;
+  const screenshots = purposesList.map(purpose => {
+        const mediaItems = data.release.media.filter(m => m.purpose === purpose);
+        if (mediaItems.length === 0) return null;
+
+        return mediaItems.map((item, index) => (`
+          <div class="screenshot">
+            <img src=${item.uri} />
+          </div>`)
+        );
+      });
+  result.window.document.getElementById("screenshots").innerHTML = screenshots.join("");
+  return result.serialize();
+}
+
+export function previewCommand(): string {
+  const templatePath = path.resolve("node_modules/@solana-mobile/dapp-store-cli/src/commands/app-preview.html");
+  const template = fs.readFileSync(templatePath, "utf-8");
+  const configData = readData(); 
+  if (configData !== null) {
+    const filled = fillTemplate(template, configData);
+    const outputFileName = "app-preview.html";
+    console.log(`✅ HTML generated: ${outputFileName}`);
+    fs.writeFileSync(outputFileName, filled, "utf-8");
+    return outputFileName;
+  } else {
+    return null;
+  }
+}

--- a/packages/cli/src/commands/app-preview.html
+++ b/packages/cli/src/commands/app-preview.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>App Store Mock Page</title>
+  <style>
+    :root {
+      --bg-light: #f8f9fa;
+      --bg-dark: #0d1615;
+      --bg-white: #ffffff;
+      --text-muted: #fff;
+      --primary-color: #1e88e5;
+      --star-color: #ffaa00;
+    }
+
+    body {
+      margin: 0;
+      font-family: system-ui, sans-serif;
+      background-color: var(--bg-dark);
+      color: #fff;
+    }
+    
+    img {
+      width: 100%;
+    }
+
+    .banner {
+      width: 100%;
+      height: 160px;
+      background-color: #ddd;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.2rem;
+      color: #666;
+    }
+
+    .app-header {
+      display: flex;
+      flex-direction: column;
+      padding: 16px;
+      background-color: var(--bg-dark);
+      border-bottom: 1px solid #ccc;
+    }
+
+    .header-top {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+    }
+
+    .app-icon {
+      width: 72px;
+      height: 72px;
+      background-color: #ccc;
+      border-radius: 16px;
+      flex-shrink: 0;
+    }
+
+    .app-meta {
+      flex: 1;
+    }
+
+    .app-title {
+      font-size: 1.3rem;
+      font-weight: bold;
+    }
+
+    .app-developer {
+      color: var(--text-muted);
+      margin-top: 4px;
+      font-size: 0.95rem;
+    }
+
+    .ratings {
+      margin-top: 8px;
+      color: var(--star-color);
+      font-size: 1rem;
+    }
+
+    .install-btn {
+      margin-top: 12px;
+      width: 100%;
+      padding: 12px;
+      background-color: var(--primary-color);
+      color: #fff;
+      border: none;
+      border-radius: 8px;
+      font-size: 1rem;
+      font-weight: bold;
+      cursor: pointer;
+    }
+
+    .section {
+      padding: 16px;
+      background-color: var(--bg-dark);
+      margin-top: 10px;
+    }
+
+    .screenshots {
+      display: flex;
+      background-color: var(--bg-dark);
+      gap: 10px;
+      overflow-x: auto;
+      padding-top: 10px;
+    }
+
+    .screenshot {
+      width: 160px;
+      height: 280px;
+      background-color: #eee;
+      flex: 0 0 auto;
+      border-radius: 10px;
+    }
+
+    .description, .reviews {
+      margin-top: 10px;
+    }
+
+    .review {
+      margin-top: 10px;
+      padding-top: 10px;
+      border-top: 1px solid #ddd;
+    }
+
+    .review .stars {
+      color: var(--star-color);
+      font-size: 1rem;
+    }
+
+    .review .text {
+      margin-top: 4px;
+      font-size: 0.95rem;
+    }
+
+    /* Larger screen tweaks */
+    @media (min-width: 600px) {
+      .app-header {
+        flex-direction: row;
+        align-items: center;
+      }
+
+      .app-meta {
+        margin-right: auto;
+      }
+
+      .install-btn {
+        width: auto;
+        margin-top: 0;
+        padding: 10px 20px;
+      }
+    }
+  </style>
+</head>
+<body>
+
+  <div class="banner" id="banner">[ Banner Image Placeholder ]</div>
+
+  <div class="app-header">
+    <div class="header-top">
+      <div class="app-icon" id="app-icon"></div>
+      <div class="app-meta">
+        <div class="app-title" id="app-title">[ App Title ]</div>
+        <div class="app-developer" id="app-developer">[ Developer Name ]</div>
+        <div class="ratings">★★★★☆ (4.2)</div>
+      </div>
+    </div>
+    <button class="install-btn">Install</button>
+  </div>
+
+  <div class="section">
+    <h3>Screenshots</h3>
+    <div class="screenshots" id="screenshots">
+      <div class="screenshot"></div>
+      <div class="screenshot"></div>
+      <div class="screenshot"></div>
+      <div class="screenshot"></div>
+    </div>
+  </div>
+
+  <div class="section description" id="description">
+    <h3>About this app</h3>
+    <p>This is a placeholder for the long description of the app. It gives details about features, benefits, and usage.</p>
+  </div>
+
+  <div class="section reviews">
+    <h3>User Reviews</h3>
+
+    <div class="review">
+      <div class="stars">★★★★★</div>
+      <div class="text">"Amazing app! Very helpful and easy to use."</div>
+    </div>
+
+    <div class="review">
+      <div class="stars">★★★☆☆</div>
+      <div class="text">"It's okay, but needs some improvements."</div>
+    </div>
+
+    <div class="review">
+      <div class="stars">★★★★☆</div>
+      <div class="text">"Great design and functionality. Highly recommend."</div>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,3 +1,4 @@
 export * from "./create/index.js";
 export * from "./publish/index.js";
 export * from "./ValidateCommand.js";
+export * from "./PreviewCommand.js";


### PR DESCRIPTION
This currently assumes `config.yaml` and directory `media` are present in the root directory of the development app and are correct. 

Requires a new dev-only dependency `JSDOM` to use and modify the HTML DOM of the mock-appstore template. Attached are screenshots with the example config for "Cute Kittens". 

<img width="763" height="843" alt="CuteKittensMockUp" src="https://github.com/user-attachments/assets/fa1648ae-05c4-4c8d-a2c7-1218f74046c1" />

I created a generic and minimal app-store-like page, which is also included in the pull-request here. 

Edit: The ratings/reviews are only for appearance, and are hard-coded in the html template. 